### PR TITLE
Update: Added PL Fantasy Service

### DIFF
--- a/app/services/pl_fantasy_api_service.rb
+++ b/app/services/pl_fantasy_api_service.rb
@@ -1,0 +1,25 @@
+class PLFantasyApiService
+  attr_reader :connection
+
+  def initialize
+    @connection = Faraday.new('https://fantasy.premierleague.com/drf/')
+  end
+
+  # /bootstrap endpoint
+  def all_data
+    response = connection.get('bootstrap')
+    JSON.parse(response.body)
+  end
+
+  def events
+    all_data["events"]
+  end
+
+  def elements
+    all_data["elements"]
+  end
+
+  def teams
+    all_data["teams"]
+  end
+end


### PR DESCRIPTION
Using Faraday, pull all data from PL Fantasy API primary endpoint.
Added methods for parsing just events, elements(players) and teams from API