### PR TITLE
Update: added PL and Individual team Services

### DIFF
--- a/app/services/leagues/premier_league_service.rb
+++ b/app/services/leagues/premier_league_service.rb
@@ -1,0 +1,13 @@
+module Leagues
+  class PremierLeagueService
+    def self.league_details
+      connection = ApiFootballApiService.new
+      connection.premier_league
+    end
+
+    def self.premier_league_teams
+      connection = ApiFootballApiService.new
+      connection.premier_league_teams
+    end
+  end
+end

--- a/app/services/teams/premier_league/bournemouth_service.rb
+++ b/app/services/teams/premier_league/bournemouth_service.rb
@@ -1,0 +1,17 @@
+module Teams
+  module PremierLeague
+    class Bournemouth
+      def self.team_details
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('teams/team/35')
+        JSON.parse(response.body)
+      end
+
+      def self.team_roster
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('players/2018/35')
+        JSON.parse(response.body)
+      end
+    end
+  end
+end

--- a/app/services/teams/premier_league/cardiff_service.rb
+++ b/app/services/teams/premier_league/cardiff_service.rb
@@ -1,0 +1,17 @@
+module Teams
+  module PremierLeague
+    class Cardiff
+      def self.team_details
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('teams/team/43')
+        JSON.parse(response.body)
+      end
+
+      def self.team_roster
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('players/2018/43')
+        JSON.parse(response.body)
+      end
+    end
+  end
+end

--- a/app/services/teams/premier_league/chelsea_service.rb
+++ b/app/services/teams/premier_league/chelsea_service.rb
@@ -1,0 +1,17 @@
+module Teams
+  module PremierLeague
+    class Chelsea
+      def self.team_details
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('teams/team/49')
+        JSON.parse(response.body)
+      end
+
+      def self.team_roster
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('players/2018/49')
+        JSON.parse(response.body)
+      end
+    end
+  end
+end

--- a/app/services/teams/premier_league/crystal_palace_service.rb
+++ b/app/services/teams/premier_league/crystal_palace_service.rb
@@ -1,0 +1,17 @@
+module Teams
+  module PremierLeague
+    class CrystalPalace
+      def self.team_details
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('teams/team/52')
+        JSON.parse(response.body)
+      end
+
+      def self.team_roster
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('players/2018/52')
+        JSON.parse(response.body)
+      end
+    end
+  end
+end

--- a/app/services/teams/premier_league/fulham_service.rb
+++ b/app/services/teams/premier_league/fulham_service.rb
@@ -1,0 +1,17 @@
+module Teams
+  module PremierLeague
+    class Fulham
+      def self.team_details
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('teams/team/36')
+        JSON.parse(response.body)
+      end
+
+      def self.team_roster
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('players/2018/36')
+        JSON.parse(response.body)
+      end
+    end
+  end
+end

--- a/app/services/teams/premier_league/huddersfield_service.rb
+++ b/app/services/teams/premier_league/huddersfield_service.rb
@@ -1,0 +1,17 @@
+module Teams
+  module PremierLeague
+    class Huddersfield
+      def self.team_details
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('teams/team/37')
+        JSON.parse(response.body)
+      end
+
+      def self.team_roster
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('players/2018/37')
+        JSON.parse(response.body)
+      end
+    end
+  end
+end

--- a/app/services/teams/premier_league/leicester_service.rb
+++ b/app/services/teams/premier_league/leicester_service.rb
@@ -1,0 +1,17 @@
+module Teams
+  module PremierLeague
+    class Leicester
+      def self.team_details
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('teams/team/46')
+        JSON.parse(response)
+      end
+
+      def self.team_roster
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('players/2018/46')
+        JSON.parse(response)
+      end
+    end
+  end
+end

--- a/app/services/teams/premier_league/manchester_united_service.rb
+++ b/app/services/teams/premier_league/manchester_united_service.rb
@@ -1,0 +1,17 @@
+module Teams
+  module PremierLeague
+    class ManchesterUnited
+      def self.team_details
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('teams/team/33')
+        JSON.parse(response.body)
+      end
+
+      def self.team_roster
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('players/2018/33')
+        JSON.parse(response.body)
+      end
+    end
+  end
+end

--- a/app/services/teams/premier_league/newcastle_service.rb
+++ b/app/services/teams/premier_league/newcastle_service.rb
@@ -1,0 +1,17 @@
+module Teams
+  module PremierLeague
+    class Newcastle
+      def self.team_details
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('teams/team/34')
+        JSON.parse(response.body)
+      end
+
+      def self.team_roster
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('players/2018/34')
+        JSON.parse(response.body)
+      end
+    end
+  end
+end

--- a/app/services/teams/premier_league/tottenham_service.rb
+++ b/app/services/teams/premier_league/tottenham_service.rb
@@ -1,0 +1,17 @@
+module Teams
+  module PremierLeague
+    class Tottenham
+      def self.team_details
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('teams/team/47')
+        JSON.parse(response)
+      end
+
+      def self.team_roster
+        conn = ApiFootballApiService.new
+        response = conn.connection.get('players/2018/47')
+        JSON.parse(response)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added PL League service that pulls league details and team listings.
Added individual services for Bournmouth, Cardiff, Chelsea, Crystal Palace, Fulham, Huddersfield, Leiscester, Man U, Newcastle and Tottenham.